### PR TITLE
feat: update markdown widget renderer

### DIFF
--- a/src/Post/Markdown.jsx
+++ b/src/Post/Markdown.jsx
@@ -93,6 +93,7 @@ const renderWidget =
   props.renderWidget ??
   // URL pattern: scheme://authority@path?query#fragment
   (({ url, scheme, authority, path, query }) => {
+    // widget URL now allows "bos" and "near" schemes
     if (url && ["bos", "near"].includes(scheme) && authority && path) {
       const location = authority + path;
       const segments = location.split("/");
@@ -109,7 +110,7 @@ const renderWidget =
         );
       }
     }
-    // If not an expected widget URL, return the original URL
+    // If not a valid widget URL, return the original URL
     return url;
   });
 

--- a/src/Post/Markdown.jsx
+++ b/src/Post/Markdown.jsx
@@ -72,7 +72,7 @@ const Wrapper = styled.div`
   }
 `;
 
-const Embedded = styled.div`
+const Embedded = styled.span`
   white-space: normal;
 `;
 
@@ -91,29 +91,33 @@ const renderMention =
 
 const renderWidget =
   props.renderWidget ??
-  (({ src, props }) => (
-    <Embedded className="embedded-widget">
-      <Widget
-        key={
-          src + props
-            ? "?" +
-              Object.entries(props)
-                .map((p) => p.join("="))
-                .join("&")
-            : ""
-        }
-        src={src}
-        props={props}
-      />
-    </Embedded>
-  ));
+  // URL pattern: scheme://authority@path?query#fragment
+  (({ url, scheme, authority, path, query }) => {
+    if (url && scheme === "bos" && authority && path) {
+      const location = authority + path;
+      const segments = location.split("/");
+      if (segments && segments.length >= 3) {
+        const src = segments.slice(segments.length - 3).join("/");
+        const props = {
+          ...{ markdown: props.text },
+          ...(query ?? {}),
+        };
+        return (
+          <Embedded className="embedded-widget">
+            <Widget key={url} src={src} props={props} />
+          </Embedded>
+        );
+      }
+    }
+    return undefined;
+  });
 
 return (
   <Wrapper>
     <Markdown
       text={props.text}
       onMention={renderMention}
-      onWidget={renderWidget}
+      onURL={renderWidget}
     />
   </Wrapper>
 );

--- a/src/Post/Markdown.jsx
+++ b/src/Post/Markdown.jsx
@@ -93,7 +93,7 @@ const renderWidget =
   props.renderWidget ??
   // URL pattern: scheme://authority@path?query#fragment
   (({ url, scheme, authority, path, query }) => {
-    if (url && scheme === "bos" && authority && path) {
+    if (url && ["bos", "near"].includes(scheme) && authority && path) {
       const location = authority + path;
       const segments = location.split("/");
       if (segments && segments.length >= 3) {
@@ -109,7 +109,8 @@ const renderWidget =
         );
       }
     }
-    return undefined;
+    // If not an expected widget URL, return the original URL
+    return url;
   });
 
 return (


### PR DESCRIPTION
Based on the latest implementation in https://github.com/openwebbuild/bos-vm/pull/2/files, now we use `onURL` handler to process BOS URLs such as `bos://near.org/mob.near/widget/Profile?accountId=root.near` in Markdown. 